### PR TITLE
Send numeric values in DataFrames as JSON numeric values to avoid locale-specific misinterpretation 

### DIFF
--- a/gspread_dataframe.py
+++ b/gspread_dataframe.py
@@ -13,6 +13,7 @@ from gspread.utils import fill_gaps
 from gspread.models import Cell
 import logging
 import re
+from numbers import Real
 
 try:
     from collections.abc import defaultdict
@@ -79,10 +80,10 @@ def _cellrepr(value, allow_formulas, string_escaping):
     """
     if pd.isnull(value) is True:
         return ""
-    if isinstance(value, float):
-        value = repr(value)
-    else:
-        value = str(value)
+    if isinstance(value, Real):
+        return value
+
+    value = str(value)
     if ((not allow_formulas) and value.startswith('=')):
         value = "'%s" % value
     else:

--- a/tests/gspread_dataframe_integration.py
+++ b/tests/gspread_dataframe_integration.py
@@ -154,9 +154,9 @@ class WorksheetTest(GspreadDataframeTest):
         df = get_as_dataframe(self.sheet)
         set_with_dataframe(self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN)
         df2 = get_as_dataframe(self.sheet)
-        self.assertTrue(df.equals(df2))
         # check that some numeric values in numeric column are intact
         self.assertEqual(3.804, df2["Numeric Column"][3])
+        self.assertTrue(df.equals(df2))
 
     def test_nrows(self):
         # populate sheet with cell list values


### PR DESCRIPTION
Fixes #29. Ensures that numeric values in DataFrames are sent to Sheets API as JSON numeric
values, so that locale-specific parsing of decimal separators cannot misinterpret
the stringified decimal values. Test coverage added.