### PR TITLE
Fixes #31. Serializes numpy numeric scalars as their Python equivalents

### DIFF
--- a/gspread_dataframe.py
+++ b/gspread_dataframe.py
@@ -35,12 +35,8 @@ major, minor = tuple(
     [int(i) for i in re.search(r"^(\d+)\.(\d+)\..+$", pd.__version__).groups()]
 )
 if (major, minor) < (0, 14):
-    raise ImportError(
-        "pandas version too old (<0.14.0) to support gspread_dataframe"
-    )
-logger.debug(
-    "Imported satisfactory (>=0.14.0) Pandas module: %s", pd.__version__
-)
+    raise ImportError("pandas version too old (<0.14.0) to support gspread_dataframe")
+logger.debug("Imported satisfactory (>=0.14.0) Pandas module: %s", pd.__version__)
 
 __all__ = ("set_with_dataframe", "get_as_dataframe")
 
@@ -81,7 +77,7 @@ def _cellrepr(value, allow_formulas, string_escaping):
     # numpy scalars should yield their Python equivalents
     if isinstance(value, np.generic):
         value = value.item()
-        
+
     if isinstance(value, Real):
         return value
 
@@ -263,8 +259,7 @@ def set_with_dataframe(
                 if not isinstance(index_elts, (list, tuple)):
                     index_elts = [index_elts]
                 elts = [
-                    ((None,) * (column_header_size - 1)) + (e,)
-                    for e in index_elts
+                    ((None,) * (column_header_size - 1)) + (e,) for e in index_elts
                 ] + elts
             for level in range(0, column_header_size):
                 for idx, tup in enumerate(elts):
@@ -272,9 +267,7 @@ def set_with_dataframe(
                         (
                             row,
                             col + idx,
-                            _cellrepr(
-                                tup[level], allow_formulas, string_escaping
-                            ),
+                            _cellrepr(tup[level], allow_formulas, string_escaping),
                         )
                     )
                 row += 1
@@ -299,9 +292,7 @@ def set_with_dataframe(
             row += 1
 
     values = []
-    for value_row, index_value in zip_longest(
-        dataframe.values, dataframe.index
-    ):
+    for value_row, index_value in zip_longest(dataframe.values, dataframe.index):
         if include_index:
             if not isinstance(index_value, (list, tuple)):
                 index_value = [index_value]
@@ -324,7 +315,5 @@ def set_with_dataframe(
     cells_to_update = [Cell(row, col, value) for row, col, value in updates]
     logger.debug("%d cell updates to send", len(cells_to_update))
 
-    resp = worksheet.update_cells(
-        cells_to_update, value_input_option="USER_ENTERED"
-    )
+    resp = worksheet.update_cells(cells_to_update, value_input_option="USER_ENTERED")
     logger.debug("Cell update response: %s", resp)

--- a/gspread_dataframe.py
+++ b/gspread_dataframe.py
@@ -13,6 +13,7 @@ from gspread.utils import fill_gaps
 from gspread.models import Cell
 import pandas as pd
 from pandas.io.parsers import TextParser
+import numpy as np
 import logging
 import re
 from numbers import Real
@@ -76,6 +77,11 @@ def _cellrepr(value, allow_formulas, string_escaping):
     """
     if pd.isnull(value) is True:
         return ""
+
+    # numpy scalars should yield their Python equivalents
+    if isinstance(value, np.generic):
+        value = value.item()
+        
     if isinstance(value, Real):
         return value
 

--- a/tests/gspread_dataframe_integration.py
+++ b/tests/gspread_dataframe_integration.py
@@ -148,9 +148,7 @@ class WorksheetTest(GspreadDataframeTest):
         self.sheet.update_cells(cell_list)
 
         df = get_as_dataframe(self.sheet)
-        set_with_dataframe(
-            self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN
-        )
+        set_with_dataframe(self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN)
         df2 = get_as_dataframe(self.sheet)
         self.assertTrue(df.equals(df2))
 
@@ -166,11 +164,19 @@ class WorksheetTest(GspreadDataframeTest):
             cell.value = value
         self.sheet.update_cells(cell_list)
 
-        df = get_as_dataframe(self.sheet, dtypes={'Numeric Column': np.int64})
-        set_with_dataframe(
-            self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN
+        def np_int64_converter(v):
+            try:
+                return np.int64(v)
+            except:
+                return np.nan
+
+        df = get_as_dataframe(
+            self.sheet, converters={"Numeric Column": np_int64_converter}
         )
-        df2 = get_as_dataframe(self.sheet, dtypes={'Numeric Column': np.int64})
+        set_with_dataframe(self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN)
+        df2 = get_as_dataframe(
+            self.sheet, converters={"Numeric Column": np_int64_converter}
+        )
         self.assertTrue(df.equals(df2))
 
     def test_numeric_values_with_spanish_locale(self):
@@ -199,9 +205,7 @@ class WorksheetTest(GspreadDataframeTest):
         self.sheet.update_cells(cell_list)
 
         df = get_as_dataframe(self.sheet)
-        set_with_dataframe(
-            self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN
-        )
+        set_with_dataframe(self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN)
         df2 = get_as_dataframe(self.sheet)
         # check that some numeric values in numeric column are intact
         self.assertEqual(3.804, df2["Numeric Column"][3])

--- a/tests/gspread_dataframe_integration.py
+++ b/tests/gspread_dataframe_integration.py
@@ -9,6 +9,7 @@ import uuid
 import json
 from datetime import datetime, date
 import pandas as pd
+import numpy as np
 from gspread_dataframe import get_as_dataframe, set_with_dataframe
 
 try:
@@ -151,6 +152,25 @@ class WorksheetTest(GspreadDataframeTest):
             self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN
         )
         df2 = get_as_dataframe(self.sheet)
+        self.assertTrue(df.equals(df2))
+
+    def test_roundtrip_numpy_values(self):
+        # populate sheet with cell list values
+        rows = None
+        with open(CELL_LIST_FILENAME) as f:
+            rows = json.load(f)
+
+        self.sheet.resize(10, 10)
+        cell_list = self.sheet.range("A1:J10")
+        for cell, value in zip(cell_list, itertools.chain(*rows)):
+            cell.value = value
+        self.sheet.update_cells(cell_list)
+
+        df = get_as_dataframe(self.sheet, dtypes={'Numeric Column': np.int64})
+        set_with_dataframe(
+            self.sheet, df, string_escaping=STRING_ESCAPING_PATTERN
+        )
+        df2 = get_as_dataframe(self.sheet, dtypes={'Numeric Column': np.int64})
         self.assertTrue(df.equals(df2))
 
     def test_numeric_values_with_spanish_locale(self):

--- a/tests/gspread_dataframe_test.py
+++ b/tests/gspread_dataframe_test.py
@@ -53,9 +53,7 @@ class TestStringEscaping(unittest.TestCase):
     VALUES_WITH_LEADING_APOSTROPHE = ("'foo", "'")
     VALUES_NEVER_ESCAPED = ("",)
 
-    def _run_values_for_escape_args(
-        self, escape_arg, escaped_values, unescaped_values
-    ):
+    def _run_values_for_escape_args(self, escape_arg, escaped_values, unescaped_values):
         for value in escaped_values:
             self.assertEqual(escape(value, escape_arg), "'" + value)
         for value in unescaped_values:
@@ -155,13 +153,9 @@ class TestWorksheetReads(unittest.TestCase):
         self.assertEqual(len(df), 6)
 
     def test_prefix(self):
-        df = get_as_dataframe(
-            self.sheet, skiprows=[0], header=None, prefix="COL"
-        )
+        df = get_as_dataframe(self.sheet, skiprows=[0], header=None, prefix="COL")
         self.assertEqual(len(df), 9)
-        self.assertEqual(
-            df.columns.tolist(), ["COL" + str(i) for i in range(10)]
-        )
+        self.assertEqual(df.columns.tolist(), ["COL" + str(i) for i in range(10)])
 
     def test_squeeze(self):
         df = get_as_dataframe(self.sheet, usecols=[0], squeeze=True)
@@ -171,9 +165,7 @@ class TestWorksheetReads(unittest.TestCase):
     def test_converters_datetime(self):
         df = get_as_dataframe(
             self.sheet,
-            converters={
-                "Date Column": lambda x: datetime.strptime(x, "%Y-%m-%d")
-            },
+            converters={"Date Column": lambda x: datetime.strptime(x, "%Y-%m-%d")},
         )
         self.assertEqual(df["Date Column"][0], datetime(2017, 3, 4))
 
@@ -251,11 +243,7 @@ Mock._format_mock_failure_message = _format_mock_failure_message
 def __eq__(self, other):
     if not isinstance(other, self.__class__):
         return False
-    return (
-        self.row == other.row
-        and self.col == other.col
-        and self.value == other.value
-    )
+    return self.row == other.row and self.col == other.col and self.value == other.value
 
 
 Cell.__eq__ = __eq__

--- a/tests/mock_worksheet.py
+++ b/tests/mock_worksheet.py
@@ -62,10 +62,7 @@ class MockWorksheet(object):
 
 class MockSpreadsheet(object):
     def values_get(self, *args, **kwargs):
-        if (
-            kwargs.get("params", {}).get("valueRenderOption")
-            == "UNFORMATTED_VALUE"
-        ):
+        if kwargs.get("params", {}).get("valueRenderOption") == "UNFORMATTED_VALUE":
             return SHEET_CONTENTS_EVALUATED
         if kwargs.get("params", {}).get("valueRenderOption") == "FORMULA":
             return SHEET_CONTENTS_FORMULAS


### PR DESCRIPTION
...so that gspread's JSON encoder won't reject them as unserializable.