### PR TITLE
support unicode character

### DIFF
--- a/gspread_dataframe.py
+++ b/gspread_dataframe.py
@@ -79,7 +79,7 @@ def _cellrepr(value, allow_formulas, string_escaping):
     if isinstance(value, Real):
         return value
 
-    value = value.encode('utf-8')
+    value = value.encode('utf-8') if isintance(value, unicode) else str(value)
     if (not allow_formulas) and value.startswith("="):
         value = "'%s" % value
     else:

--- a/gspread_dataframe.py
+++ b/gspread_dataframe.py
@@ -79,7 +79,7 @@ def _cellrepr(value, allow_formulas, string_escaping):
     if isinstance(value, Real):
         return value
 
-    value = str(value)
+    value = value.encode('utf-8')
     if (not allow_formulas) and value.startswith("="):
         value = "'%s" % value
     else:


### PR DESCRIPTION
  File "C:\Python27\lib\site-packages\gspread_dataframe.py", line 86, in _cellrepr
    value = str(value)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)

Hi, i am using the set_with_dataframe() while having some cells with Chinese characters, and i encounter the error above. I don't know it just doesn't support unicode or is me using it wrongly. 
then i change the str() to encode('utf-8'), the error is gone. If it won't bring other bugs, maybe you should change it.