### PR TITLE
Fix JSON problem for numpy dtypes like int64

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Requirements
 
 * Python 2.7, 3+
 * gspread (>=3.0.0; to use older versions of gspread, use gspread-dataframe releases of 2.1.1 or earlier)
-* Pandas >= 0.14.0
+* Pandas >= 0.24.0
 
 From PyPI
 ~~~~~~~~~

--- a/gspread_dataframe.py
+++ b/gspread_dataframe.py
@@ -34,12 +34,12 @@ logger = logging.getLogger(__name__)
 major, minor = tuple(
     [int(i) for i in re.search(r"^(\d+)\.(\d+)\..+$", pd.__version__).groups()]
 )
-if (major, minor) < (0, 14):
+if (major, minor) < (0, 24):
     raise ImportError(
-        "pandas version too old (<0.14.0) to support gspread_dataframe"
+        "pandas version too old (<0.24.0) to support gspread_dataframe"
     )
 logger.debug(
-    "Imported satisfactory (>=0.14.0) Pandas module: %s", pd.__version__
+    "Imported satisfactory (>=0.24.0) Pandas module: %s", pd.__version__
 )
 
 __all__ = ("set_with_dataframe", "get_as_dataframe")
@@ -298,7 +298,7 @@ def set_with_dataframe(
 
     values = []
     for value_row, index_value in zip_longest(
-        dataframe.values, dataframe.index
+        dataframe.to_numpy('object'), dataframe.index.to_numpy('object')
     ):
         if include_index:
             if not isinstance(index_value, (list, tuple)):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     test_suite='tests',
     install_requires=[
         'gspread>=3.0.0', 
-        'pandas>=0.14.0',
+        'pandas>=0.24.0',
         'six>=1.12.0'
         ],
     tests_require=['oauth2client'] + ([] if PY3 else ['mock']),

--- a/tests/gspread_dataframe_integration.py
+++ b/tests/gspread_dataframe_integration.py
@@ -269,6 +269,24 @@ class WorksheetTest(GspreadDataframeTest):
         df2 = get_as_dataframe(self.sheet, header=[0, 1])
         self.assertTrue(df.equals(df2))
 
+    def test_int64_json_issue35(self):
+        df = pd.DataFrame(
+            {
+                'a':pd.Series([1, 2, 3],dtype='int64',index=pd.RangeIndex(start=0, stop=3, step=1)),
+                'b':pd.Series([4, 5, 6],dtype='int64',index=pd.RangeIndex(start=0, stop=3, step=1))
+            },
+            index=pd.RangeIndex(start=0, stop=3, step=1)
+        )
+        set_with_dataframe(
+            self.sheet,
+            df,
+            resize=True,
+            include_index=True
+        )
+        self.sheet = self.sheet.spreadsheet.worksheet(self.sheet.title)
+        df2 = get_as_dataframe(self.sheet, dtype={'a': 'int64', 'b': 'int64'}, index_col=0)
+        self.assertTrue(df.equals(df2))
+
     def test_multiindex_column_header_and_multiindex(self):
         # populate sheet with cell list values
         rows = None


### PR DESCRIPTION
Fixes #35. Use `to_numpy('object')` to perform needed type conversionson frame and index values before attempting to update cell values in the worksheet. Now requires Pandas>=0.24.0 instead of >=0.14.0.