### PR TITLE
Fixes #37

### DIFF
--- a/gspread_dataframe.py
+++ b/gspread_dataframe.py
@@ -44,6 +44,7 @@ logger.debug(
 
 __all__ = ("set_with_dataframe", "get_as_dataframe")
 
+WORKSHEET_MAX_CELL_COUNT = 5000000
 
 def _escaped_string(value, string_escaping):
     if value in (None, ""):
@@ -97,15 +98,49 @@ def _resize_to_minimum(worksheet, rows=None, cols=None):
 
     Both rows and cols are optional.
     """
-    # get the current size
-    current_cols, current_rows = (worksheet.col_count, worksheet.row_count)
-    if rows is not None and rows <= current_rows:
-        rows = None
-    if cols is not None and cols <= current_cols:
-        cols = None
+    current_rows, current_cols = (worksheet.row_count, worksheet.col_count)
+    desired_rows, desired_cols = (rows, cols)
+    if desired_rows is not None and desired_rows <= current_rows:
+        desired_rows = current_rows
+    if desired_cols is not None and desired_cols <= current_cols:
+        desired_cols = current_cols
+    resize_cols_first = False
+    if desired_rows is not None and desired_cols is not None:
+        # special case: if desired sheet size now > cell limit for sheet,
+        # resize to exactly rows x cols, which in certain cases will 
+        # allow worksheet to stay within cell limit.
+        if desired_rows * desired_cols > WORKSHEET_MAX_CELL_COUNT:
+            desired_rows, desired_cols = (rows, cols)
 
-    if cols is not None or rows is not None:
-        worksheet.resize(rows, cols)
+        # Large increase that requires exact re-sizing to avoid exceeding
+        # cell limit might be, for example, 1000000 rows and 2 columns,
+        # for a worksheet that currently has 100 rows and 26 columns..
+        # The sheets API, however, applies new rowCount first, then
+        # checks against cell count limit before applying new colCount!
+        # In the above case, applying new rowCount produces 26 million
+        # cells, the limit is exceeded, and API aborts the change and
+        # returns a 400 response.
+        # So to avoid a 400 response, we must in these cases have
+        # _resize_to_minimum call resize twice, first with the value
+        # that will reduce cell count and second with the value that
+        # will increase cell count.
+        # We don't seem to need to address the reversed case, where
+        # columnCount is applied first, since Sheets API seems to apply
+        # rowCount first in all cases. There is test coverage of this
+        # reversed case, to guard against Sheets API changes in future.
+        if (
+            cols is not None and 
+            cols < current_cols and 
+            desired_rows * current_cols > WORKSHEET_MAX_CELL_COUNT
+        ):
+            resize_cols_first = True
+
+    if desired_cols is not None or desired_rows is not None:
+        if resize_cols_first:
+            worksheet.resize(cols=desired_cols)
+            worksheet.resize(rows=desired_rows)
+        else:
+            worksheet.resize(desired_rows, desired_cols)
 
 
 def _get_all_values(worksheet, evaluate_formulas):


### PR DESCRIPTION
Discovered that Sheets API applies rowCount first, and THEN checks cell limits, so that if new rowCount * existing colCount > 5000000, then worksheet exceeds limit of 5000000 cells and the whole resize operation is aborted. Solution is to determine if such a condition would occur and then issue the smaller columnCount first as a separate call to reduce cell count. Full test coverage included.